### PR TITLE
Use single-precision floating point.

### DIFF
--- a/futcam_transforms.fut
+++ b/futcam_transforms.fut
@@ -1,15 +1,17 @@
+default (f32)
+
 type pixel = [3]u8 -- Well, it works.
 
 entry scale_to(frame : [h0][w0]pixel, w1 : i32, h1 : i32) : [h1][w1]pixel =
-  let y_factor = (f64 h1) / (f64 h0)
-  let x_factor = (f64 w1) / (f64 w0)
+  let y_factor = (f32 h1) / (f32 h0)
+  let x_factor = (f32 w1) / (f32 w0)
   in map (fn (y1 : i32) : [w1]pixel =>
             map (fn (x1 : i32) : pixel =>
-                   let y1_norm = f64 (y1 - h1 / 2)
+                   let y1_norm = f32 (y1 - h1 / 2)
                    let y0_norm = y1_norm / y_factor
                    let y0 = (i32 y0_norm) + h0 / 2
                    
-                   let x1_norm = f64 (x1 - w1 / 2)
+                   let x1_norm = f32 (x1 - w1 / 2)
                    let x0_norm = x1_norm / x_factor
                    let x0 = (i32 x0_norm) + w0 / 2
                    
@@ -46,20 +48,20 @@ entry dim_sides(frame : [h][w]pixel) : [h][w]pixel =
          (zip row (iota w)))
   (zip frame (iota h))
 
-entry distort(frame : [h][w]pixel, distortion : f64) : [h][w]pixel =
+entry distort(frame : [h][w]pixel, distortion : f32) : [h][w]pixel =
   map (fn (y : i32) : [w]pixel =>
          map (fn (x : i32) : pixel =>
-                let y_scale = ((f64 (h / 2)) ** distortion) / (f64 (h / 2))
-                let x_scale = ((f64 (w / 2)) ** distortion) / (f64 (w / 2))
+                let y_scale = ((f32 (h / 2)) ** distortion) / (f32 (h / 2))
+                let x_scale = ((f32 (w / 2)) ** distortion) / (f32 (w / 2))
 
-                let y_norm_base = f64 (y - h / 2)
-                let y_lz = y_norm_base < 0.0f64
+                let y_norm_base = f32 (y - h / 2)
+                let y_lz = y_norm_base < 0.0f32
                 let y_norm = if y_lz then -y_norm_base else y_norm_base
                 let y' = (y_norm ** distortion) / y_scale
                 let y_back = i32 (if y_lz then -y' else y') + h / 2
 
-                let x_norm_base = f64 (x - w / 2)
-                let x_lz = x_norm_base < 0.0f64
+                let x_norm_base = f32 (x - w / 2)
+                let x_lz = x_norm_base < 0.0f32
                 let x_norm = if x_lz then -x_norm_base else x_norm_base
                 let x' = (x_norm ** distortion) / x_scale
                 let x_back = i32 (if x_lz then -x' else x') + w / 2


### PR DESCRIPTION
This makes it run on GPUs that do not support double-precision.
